### PR TITLE
Fixed - Hole cards get exposed during the River, before the Show Down

### DIFF
--- a/privatebet/host.c
+++ b/privatebet/host.c
@@ -2169,7 +2169,7 @@ int32_t BET_evaluate_hand_test(cJSON *playerCardInfo,struct privatebet_info *bet
 	
 	for(int i=0;i<bet->maxplayers;i++)
 	{
-			p[i]=vars->bet_actions[i][(vars->round-1)];
+			p[i]=vars->bet_actions[i][(vars->round)];
 			
 			if(vars->bet_actions[i][vars->round]==fold)//|| (vars->bet_actions[i][vars->round]==allin)) 
 				players_left++;

--- a/privatebet/states.c
+++ b/privatebet/states.c
@@ -145,6 +145,7 @@ int32_t BET_DCV_round_betting(cJSON *argjson,struct privatebet_info *bet,struct 
 
 		if((vars->round>=CARDS777_MAXROUNDS) || (players_left<2))
 		{
+			vars->round-=1;
 			retval=BET_evaluate_hand_test(argjson,bet,vars);
 			goto end;
 		}


### PR DESCRIPTION
Made changes to fix Hole cards get exposed during the River, before the Show Down chips-blockchain/pangea-poker#48.
