### PR TITLE
Fixed - Raise enum doesn't always get sent with the possibilities

### DIFF
--- a/privatebet/states.c
+++ b/privatebet/states.c
@@ -267,7 +267,7 @@ int32_t BET_DCV_round_betting(cJSON *argjson,struct privatebet_info *bet,struct 
 				{
 					for(int j=0;j<bet->maxplayers;j++)
 					{
-						if((j != vars->turni)&&(vars->funds[i] != 0))
+						if((j != vars->turni)&&(vars->funds[j] != 0))
 						{
 							cJSON_AddItemToArray(possibilities,cJSON_CreateNumber(i));
 							break;


### PR DESCRIPTION
Changes are made to fix the issue of `Raise enum is not populating properly even in valid scenarios as mentioned in` chips-blockchain/pangea-poker#56. 