### PR TITLE
Fix Show Down gets triggered Post-Flop after one player goes All-In

### DIFF
--- a/privatebet/states.c
+++ b/privatebet/states.c
@@ -557,29 +557,23 @@ int32_t BET_p2p_betting_statemachine(cJSON *argjson,struct privatebet_info *bet,
 			}
 			else if(strcmp(action,"round_betting") == 0)
 			{
-				if(bet->myplayerid == jint(argjson,"playerid"))
-				{
-					display_cards(argjson,bet,vars);
-					cJSON *player_funds=NULL;
-					cJSON_AddItemToObject(argjson,"player_funds",player_funds=cJSON_CreateArray());
+				display_cards(argjson,bet,vars);
 
-					
-					for(int i=0;i<bet->maxplayers;i++)
-					{
-						int totalBet=0;
-						for(int j=0;j<=jint(argjson,"round");j++)  //for(int j=0;j<=vars->round;j++)
-						{
-							totalBet+=vars->betamount[i][j];
-						}
-						cJSON_AddItemToArray(player_funds,cJSON_CreateNumber(vars->funds[i]-totalBet));
-					}	
-					player_lws_write(argjson);
-				}
-				else
+				cJSON *player_funds=NULL;
+				cJSON_AddItemToObject(argjson,"player_funds",player_funds=cJSON_CreateArray());
+				
+				
+				for(int i=0;i<bet->maxplayers;i++)
 				{
-					player_lws_write(argjson);
-					display_cards(argjson,bet,vars);
-				}
+					int totalBet=0;
+					for(int j=0;j<=jint(argjson,"round");j++)  //for(int j=0;j<=vars->round;j++)
+					{
+						totalBet+=vars->betamount[i][j];
+					}
+					cJSON_AddItemToArray(player_funds,cJSON_CreateNumber(vars->funds[i]-totalBet));
+				}	
+										
+				player_lws_write(argjson);
 			}
 			else if((strcmp(action,"check") == 0) || (strcmp(action,"call") == 0) || (strcmp(action,"raise") == 0)
 									|| (strcmp(action,"fold") == 0) || (strcmp(action,"allin") == 0))																					

--- a/privatebet/states.c
+++ b/privatebet/states.c
@@ -82,44 +82,41 @@ int32_t BET_DCV_next_turn(cJSON *argjson,struct privatebet_info *bet,struct priv
 	}
 	players_left=bet->maxplayers-players_left;
 	if(players_left<2)
-		goto end;
+		return retval;
 	
 	for(int i=0;i<bet->maxplayers;i++)
 	{
 		if(maxamount<vars->betamount[i][vars->round])
 			maxamount=vars->betamount[i][vars->round];
 	}
-	
 	for(int i=((vars->turni+1)%bet->maxplayers);(i != vars->turni);i=((i+1)%bet->maxplayers))
 	{
 		if((vars->bet_actions[i][vars->round] != fold)&&(vars->bet_actions[i][vars->round] != allin)&&(vars->funds[i] != 0))
 		{
 			if(vars->bet_actions[i][vars->round] == 0)
 			{
-				retval=i;
 				
 				for(int j=0;j<bet->maxplayers;j++)
 				{
-					if((vars->funds[j] == 0)&&(j != retval))
+					if((i!=j)&&(((vars->bet_actions[j][vars->round] == 0)&&(vars->funds[j]!=0)) || 
+						(vars->bet_actions[j][vars->round] != 0)))
 					{
-						retval=-1;
-						goto end;
+						return i;
 					}
+						
 				}
 			}
 			else if(/*(vars->bet_actions[i][vars->round] == 0) ||*/ (vars->bet_actions[i][vars->round] == small_blind) || 
 				(vars->bet_actions[i][vars->round] == big_blind) ||	(((vars->bet_actions[i][vars->round] == check) || (vars->bet_actions[i][vars->round] == call) 
 										|| (vars->bet_actions[i][vars->round] == raise)) && (maxamount !=vars->betamount[i][vars->round])) )
 			{
-				retval=i;
-				goto end;
+				return i;
 								
 			}
 		}
 
 	}
-	end:
-		return retval;
+	return retval;
 		
 }
 int32_t BET_DCV_round_betting(cJSON *argjson,struct privatebet_info *bet,struct privatebet_vars *vars)
@@ -154,7 +151,6 @@ int32_t BET_DCV_round_betting(cJSON *argjson,struct privatebet_info *bet,struct 
 		goto end;
 	}
 
-	printf("%s::%d::This is the fold and allout scenario\n",__FUNCTION__,__LINE__);
 	for(int i=0;i<bet->maxplayers;i++)
 	{
 		printf("%s::%d::player id::%d::funds::%d::vars->round::%d\n",__FUNCTION__,__LINE__,i,vars->funds[i],vars->round);

--- a/privatebet/states.c
+++ b/privatebet/states.c
@@ -71,6 +71,29 @@ int32_t BET_p2p_initiate_statemachine(cJSON *argjson,struct privatebet_info *bet
 		return retval;
 }
 
+/** 
+ * 
+ * Function: BET_DCV_next_turn 
+ * 
+ * Parameters: 
+ *
+ *		structure:  cJSON *argjson contains the information about current active turn of the player
+ *		structure:  struct privatebet_info *bet contains deck and player information
+ *		structure:  privatebet_vars *vars contains the game information
+ * 
+ * Return Value :
+ * 
+ *		0 --> bet->maxplayers : It indicates there a valid turn exists in the game. 
+ *		-1 : No valid turn exists
+ * 
+ * Description: 
+ * 
+ *	  	This function identifies if there is any valid turn possible during the game, if any valid turn exists
+ *    	it returns the index of the player if not it returns -1
+ *	   
+ */
+
+
 int32_t BET_DCV_next_turn(cJSON *argjson,struct privatebet_info *bet,struct privatebet_vars *vars)
 {
 	int32_t maxamount=0,retval=-1,players_left=0;


### PR DESCRIPTION
Made changes so that after Post-Flop when one player goes all-in, the other player should be allowed to do call and fold, that fixes chips-blockchain/pangea-poker#58