### PR TITLE
Rework has been done to fix All-in does not progress well

### DIFF
--- a/privatebet/states.c
+++ b/privatebet/states.c
@@ -393,14 +393,11 @@ int32_t BET_DCV_round_betting_response(cJSON *argjson,struct privatebet_info *be
 		}
 		else if(strcmp(action,"allin") == 0)
 		{
-			for(int i=vars->round;i<CARDS777_MAXROUNDS;i++)
-				vars->bet_actions[playerid][i]=allin;
+			vars->bet_actions[playerid][round]=allin;
 		}
 		else if(strcmp(action,"fold") == 0)
 		{
-			
-			for(int i=vars->round;i<CARDS777_MAXROUNDS;i++)
-				vars->bet_actions[playerid][i]=fold;
+			vars->bet_actions[playerid][round]=fold;
 			
 		}
 


### PR DESCRIPTION
All-in does not progress when one player has chips chips-blockchain/pangea-poker#50 has been fixed. Though some changes has been made to `BET_DCV_next_turn` earlier to fix this issue, but it was observed that when a player went for `allin` or `fold` all his future actions are set with the same action in `BET_DCV_round_betting_response` and which causing the issue.