### PR TITLE
Made changes to verify the tx

### DIFF
--- a/privatebet/host.c
+++ b/privatebet/host.c
@@ -1261,6 +1261,18 @@ static void bet_dcv_process_live(cJSON *argjson)
 		
 }
 
+static int32_t bet_dcv_verify_rand_str(char *rand_str)
+{
+	int32_t retval = 0;
+	
+	for(int i = 0; i < no_of_rand_str; i++) {
+		if(strcmp(tx_rand_str[i],rand_str) == 0) {
+			retval = 1;
+			break;
+			}
+	}
+	return retval;	
+}
 static int32_t bet_dcv_verify_tx(cJSON *argjson)
 {
 	
@@ -1278,6 +1290,7 @@ static int32_t bet_dcv_verify_tx(cJSON *argjson)
 		strcpy(tx_ids[no_of_txs++], cJSON_Print(tx_info));
 		rand_str = calloc(65,sizeof(char));
 		chips_extract_data(cJSON_Print(tx_info), &rand_str);
+		retval = bet_dcv_verify_rand_str(rand_str);
 	} else 
 		retval = 0;
 	
@@ -1368,6 +1381,8 @@ int32_t bet_dcv_backend(cJSON *argjson, struct privatebet_info *bet, struct priv
 			retval = bet_dcv_stack_info_resp(bet);
 		} else if (strcmp(method, "tx") == 0) {
 			retval = bet_dcv_verify_tx(argjson);
+			if(retval == 1)
+				printf("%s::%d::Tx is Valid\n",__FUNCTION__,__LINE__);
 		} else {
 			bytes = nn_send(bet->pubsock, cJSON_Print(argjson), strlen(cJSON_Print(argjson)), 0);
 			if (bytes < 0) {

--- a/privatebet/host.c
+++ b/privatebet/host.c
@@ -1270,7 +1270,7 @@ static int32_t bet_dcv_verify_tx(cJSON *argjson)
 	
 	tx_info = cJSON_CreateObject();
 	tx_info = cJSON_GetObjectItem(argjson, "tx_info");
-	block_height = jint(argjson, "block_height")
+	block_height = jint(argjson, "block_height");
 	while (block_height < chips_get_block_count()) {
 		sleep(2);
 	}
@@ -1284,7 +1284,7 @@ static int32_t bet_dcv_verify_tx(cJSON *argjson)
 	return retval;	
 }
 
-static void bet_dcv_process_join_req(cJSON *argjson, struct privatebet_info *bet, struct privatebet_vars *vars)
+static int32_t bet_dcv_process_join_req(cJSON *argjson, struct privatebet_info *bet, struct privatebet_vars *vars)
 {
 	int32_t retval = 1;
 	

--- a/privatebet/host.c
+++ b/privatebet/host.c
@@ -1252,6 +1252,15 @@ static void bet_dcv_process_signed_raw_tx(cJSON *argjson)
 	}
 }
 
+static void bet_dcv_process_live(cJSON *argjson)
+{
+	if (strcmp(jstr(argjson, "node_type"), "bvv") == 0)
+		bvv_status = 1;
+	else if (strcmp(jstr(argjson, "node_type"), "player") == 0)
+		player_status[jint(argjson, "playerid")] = 1;
+		
+}
+
 int32_t bet_dcv_backend(cJSON *argjson, struct privatebet_info *bet, struct privatebet_vars *vars)
 {
 	char *method;
@@ -1329,10 +1338,7 @@ int32_t bet_dcv_backend(cJSON *argjson, struct privatebet_info *bet, struct priv
 		} else if (strcmp(method, "signedrawtransaction") == 0) {
 			bet_dcv_process_signed_raw_tx(argjson);
 		} else if (strcmp(method, "live") == 0) {
-			if (strcmp(jstr(argjson, "node_type"), "bvv") == 0)
-				bvv_status = 1;
-			else if (strcmp(jstr(argjson, "node_type"), "player") == 0)
-				player_status[jint(argjson, "playerid")] = 1;
+			bet_dcv_process_live(argjson);
 		} else if (strcmp(method, "stack_info_req") == 0) {
 			retval = bet_dcv_stack_info_resp(bet);
 		} else if (strcmp(method, "tx") == 0) {


### PR DESCRIPTION
Changes are made to verify the tx, the steps to be made to verify the tx are:
1. `DCV` generates the random string say `rand_str` and sends it to the player.
2. Player keep this `rand_str` in data part of the transaction and creates the tx.
3. DCV extracts the `rand_str` from data part of the tx and verifies it along with the verification of the public key from the `txwitness`