### PR TITLE
LN Channel establishment mechanism has been changed between BVV and Players

### DIFF
--- a/privatebet/bet.c
+++ b/privatebet/bet.c
@@ -212,7 +212,7 @@ static void bet_dcv_deinitialize()
 
 static void bet_dcv_thrd(char *dcv_ip, const int32_t port)
 {
-	pthread_t live_thrd, dcv_backend, dcv_thrd;
+	pthread_t /*live_thrd,*/ dcv_backend, dcv_thrd;
 
 	bet_dcv_initialize(dcv_ip, port);
 	if (OS_thread_create(&dcv_backend, NULL, (void *)bet_dcv_backend_loop, (void *)bet_dcv) != 0) {
@@ -223,6 +223,7 @@ static void bet_dcv_thrd(char *dcv_ip, const int32_t port)
 		printf("error launching bet_dcv_frontend_loop\n");
 		exit(-1);
 	}
+	#if 0
 	if (OS_thread_create(&live_thrd, NULL, (void *)bet_dcv_live_loop, (void *)bet_dcv) != 0) {
 		printf("error launching bet_dcv_live_loop]n");
 		exit(-1);
@@ -230,6 +231,7 @@ static void bet_dcv_thrd(char *dcv_ip, const int32_t port)
 	if (pthread_join(live_thrd, NULL)) {
 		printf("\nError in joining the main thread for live_thrd");
 	}
+	#endif
 	if (pthread_join(dcv_backend, NULL)) {
 		printf("\nError in joining the main thread for dcv_backend");
 	}

--- a/privatebet/client.c
+++ b/privatebet/client.c
@@ -292,9 +292,13 @@ static cJSON *bet_player_fundchannel(char *channel_id)
 
 int32_t bet_check_bvv_ready(cJSON *argjson, struct privatebet_info *bet, struct privatebet_vars *vars)
 {
-	int retval = 0, channel_state, bytes;
-	cJSON *uri_info = NULL, *bvv_ready = NULL;
-	char uri[100], channel_id[100], *rendered = NULL;
+	cJSON *bvv_ready = NULL;
+	int32_t retval = 0, bytes;
+	char *rendered = NULL;
+	#if 0
+	int32_t channel_state;
+	cJSON *uri_info = NULL;
+	char uri[100], channel_id[100];
 
 	uri_info = cJSON_GetObjectItem(argjson, "uri_info");
 	for (int i = 0; i < cJSON_GetArraySize(uri_info); i++) {
@@ -313,7 +317,7 @@ int32_t bet_check_bvv_ready(cJSON *argjson, struct privatebet_info *bet, struct 
 			ln_check_peer_and_connect(uri);
 		}
 	}
-	
+	#endif
 	bvv_ready = cJSON_CreateObject();
 	cJSON_AddStringToObject(bvv_ready, "method", "bvv_ready");
 


### PR DESCRIPTION
1. Made changes such that if the BVV LN wallet doesn't have sufficient funds then for channel establishment the funds are fetched from BVV chips wallet.
2. The channel establishment between LN and Players has been disabled, since now the payment will happen through notary nodes.
3. Heartbeat protocol has been disabled, since its creating lot of traffic, will be enabled in the future with an efficient approach