### PR TITLE
Added the functionalities to support deposit and withdraw of CHIPS

### DIFF
--- a/privatebet/client.c
+++ b/privatebet/client.c
@@ -1289,6 +1289,17 @@ int32_t bet_player_frontend(struct lws *wsi, cJSON *argjson)
 	return retval;
 }
 
+static void bet_player_wallet_info()
+{
+	cJSON *wallet_info = NULL;
+
+	wallet_info = cJSON_CreateObject();
+	cJSON_AddStringToObject(wallet_info,"method","walletInfo");
+	cJSON_AddStringToObject(wallet_info,"addr",chips_get_wallet_address());
+	cJSON_AddNumberToObject(wallet_info,"balance",chips_get_balance());
+	player_lws_write(wallet_info);
+}
+
 int lws_callback_http_player(struct lws *wsi, enum lws_callback_reasons reason, void *user, void *in, size_t len)
 {
 	cJSON *argjson = NULL;
@@ -1510,17 +1521,6 @@ static int32_t bet_player_handle_stack_info_resp(cJSON *argjson, struct privateb
 			retval = -1;
 	}
 	return retval;
-}
-
-static void bet_player_wallet_info()
-{
-	cJSON *wallet_info = NULL;
-
-	wallet_info = cJSON_CreateObject();
-	cJSON_AddStringToObject(wallet_info,"method","walletInfo");
-	cJSON_AddStringToObject(wallet_info,"addr",chips_get_wallet_address());
-	cJSON_AddNumberToObject(wallet_info,"balance",chips_get_balance());
-	player_lws_write(wallet_info);
 }
 
 int32_t bet_player_backend(cJSON *argjson, struct privatebet_info *bet, struct privatebet_vars *vars)

--- a/privatebet/client.c
+++ b/privatebet/client.c
@@ -1311,6 +1311,7 @@ int lws_callback_http_player(struct lws *wsi, enum lws_callback_reasons reason, 
 		wsi_global_client = wsi;
 		printf("%s:%d::LWS_CALLBACK_ESTABLISHED\n", __FUNCTION__, __LINE__);
 		ws_connection_status = 1;
+		bet_player_wallet_info();
 		break;
 	case LWS_CALLBACK_SERVER_WRITEABLE:
 		if (data_exists) {
@@ -1509,6 +1510,17 @@ static int32_t bet_player_handle_stack_info_resp(cJSON *argjson, struct privateb
 			retval = -1;
 	}
 	return retval;
+}
+
+static void bet_player_wallet_info()
+{
+	cJSON *wallet_info = NULL;
+
+	wallet_info = cJSON_CreateObject();
+	cJSON_AddStringToObject(wallet_info,"method","walletInfo");
+	cJSON_AddStringToObject(wallet_info,"addr",chips_get_wallet_address());
+	cJSON_AddNumberToObject(wallet_info,"balance",chips_get_balance());
+	player_lws_write(wallet_info);
 }
 
 int32_t bet_player_backend(cJSON *argjson, struct privatebet_info *bet, struct privatebet_vars *vars)

--- a/privatebet/commands.c
+++ b/privatebet/commands.c
@@ -158,18 +158,20 @@ int chips_validate_address(char *address)
 	return retval;
 }
 
-void chips_list_address_groupings()
+cJSON* chips_list_address_groupings()
 {
 	int argc;
 	char **argv = NULL;
 	cJSON *list_address_groupings = NULL;
-
+	cJSON *addr_info = NULL;
+	
 	argc = 2;
 	bet_alloc_args(argc, &argv);
 	argv = bet_copy_args(argc, "chips-cli", "listaddressgroupings");
 	list_address_groupings = cJSON_CreateObject();
 	make_command(argc, argv, &list_address_groupings);
 
+	addr_info = cJSON_CreateArray();
 	for (int i = 0; i < cJSON_GetArraySize(list_address_groupings); i++) {
 		cJSON *address_info = cJSON_GetArrayItem(list_address_groupings, i);
 		for (int j = 0; j < cJSON_GetArraySize(address_info); j++) {
@@ -177,12 +179,14 @@ void chips_list_address_groupings()
 			temp = cJSON_GetArrayItem(address_info, j);
 			cJSON *address = cJSON_GetArrayItem(temp, 0);
 			if (chips_validate_address(cJSON_Print(address)) == 1) {
+				cJSON_AddItemToArray(addr_info,address);
 				printf("%s::%f\n", cJSON_Print(address),
 				       atof(cJSON_Print(cJSON_GetArrayItem(temp, 1))));
 			}
 		}
 	}
 	bet_dealloc_args(argc, &argv);
+	return addr_info;
 }
 
 cJSON *chips_transfer_funds_with_data(double amount, char *address, char *data)

--- a/privatebet/commands.c
+++ b/privatebet/commands.c
@@ -179,7 +179,7 @@ cJSON* chips_list_address_groupings()
 			temp = cJSON_GetArrayItem(address_info, j);
 			cJSON *address = cJSON_GetArrayItem(temp, 0);
 			if (chips_validate_address(cJSON_Print(address)) == 1) {
-				cJSON_AddItemToArray(addr_info,address);
+				cJSON_AddItemToArray(addr_info,cJSON_CreateString(unstringify(cJSON_Print(address))));
 				printf("%s::%f\n", cJSON_Print(address),
 				       atof(cJSON_Print(cJSON_GetArrayItem(temp, 1))));
 			}

--- a/privatebet/commands.h
+++ b/privatebet/commands.h
@@ -4,7 +4,7 @@ void chips_spend_multi_sig_address(char *address, double amount);
 cJSON *chips_import_address(char *address);
 char *chips_get_new_address();
 int chips_validate_address(char *address);
-void chips_list_address_groupings();
+cJSON* chips_list_address_groupings();
 cJSON *chips_transfer_funds(double amount, char *address);
 cJSON *chips_send_raw_tx(cJSON *signed_tx);
 cJSON *chips_sign_raw_tx_with_wallet(char *raw_tx);


### PR DESCRIPTION
For Deposit
1. Backend sends wallerInfo to the GUI, to this address the player deposits the funds, the JSON message looks as follows:
```
{
    method: "walletInfo", 
    addr: "bQepVNtzfjMaBJdaaCq68trQDAPDgKnwrD", 
    balance: 0.13269034
}
```
For withdraw
1. GUI sends withdrawRequest to the backend 
```
{
   method: withdrawRequest
}
```
2. Backend sends withdrawResponse to the GUI 
```
{
    method: withdrawResponse,
    balace: xxxx,
    addr: [addr1,addr2,...,addrn]
}
```
3. GUI sends withdraw to the backend 
```
{
    method: withdraw,
    amount: yyyy,
    addr: some_addr_from_the_above_list
}
```
4. Backend sends withdrawInfo to the GUI
```
 {
   method: withdrawInfo,
   txid: tx_id,
   balance: zzzz
}
```
