### PR TITLE
Avoiding taking the eth0 IP for dealer and cashier nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,16 @@ Below are the list of the ports used and should be remained open incase if you h
 ```
 $ cd
 $ cd bet/privatebet
-$ ./bet dcv
+$ ./bet dcv dealer_ip
 ```
+This `dealer_ip` should be `static public ip` of a machine on which one wants to run the dealer.
+
 ### Configuring the Table
 
 The dealer can configure the table parameters, the steps to configure the table parameters are mentioned [here](./configure_dealer.md).
 
 ## Command to run BVV
+Now BVV is part of the Cashier node, so no need to start the BVV node explicitly. Dealer will choose any of the cashier nodes to act as a BVV. As we know the role of BVV is for deck shuffling.
 ```
 $ cd
 $ cd bet/privatebet
@@ -46,9 +49,11 @@ $ ./bet player
 ```
 $ cd
 $ cd bet/privatebet
-$ ./bet cashier
+$ ./bet cashier cashier_ip
 ```
-The detailed description of the cashier protocol is mentioned [here](./cashier_protocol.md)
+This `cashier_ip` should be `static public ip` of a machine on which one wants to run the cashier. The cashier nodes are the trusted nodes in the network and are elcted and chosen by the community. The set of trusted nodes at the moment are [here](./privatebet/config/cashier_nodes.json).
+
+The detailed description of the cashier protocol is mentioned [here](./cashier_protocol.md).
 
 ## Usage of this repo
 

--- a/privatebet/cashier.c
+++ b/privatebet/cashier.c
@@ -1156,7 +1156,7 @@ void find_bvv()
 				cJSON *bvv_info = NULL;
 				bvv_info = cJSON_CreateObject();
 				cJSON_AddStringToObject(bvv_info, "method", "add_bvv");
-				cJSON_AddStringToObject(bvv_info, "dealer_ip", bet_get_etho_ip());
+				cJSON_AddStringToObject(bvv_info, "dealer_ip", dealer_ip);
 				bet_msg_cashier(bvv_info, notary_node_ips[i]);
 				printf("%s::%d::bvv is::%s\n", __FUNCTION__, __LINE__, notary_node_ips[i]);
 				break;

--- a/privatebet/common.h
+++ b/privatebet/common.h
@@ -99,4 +99,7 @@ extern int32_t live_notaries;
 extern char table_id[65];
 extern int32_t bvv_state;
 
+extern char dealer_ip[20];
+extern char cashier_ip[20];
+
 #endif


### PR DESCRIPTION
Now when the dealer or cahsier nodes starts, then the static public ip of the machine where one wants to start these nodes must be entered while running.

For Dealer: `./bet dcv dealer_ip`
For Cashier: `/bet cashier cashier_ip`

