### PR TITLE
Add missing python3-mako dep for 'lightning'

### DIFF
--- a/docs/compile.md
+++ b/docs/compile.md
@@ -16,7 +16,7 @@ Tested with Ubuntu 16.04 and Ubuntu 18.04
 
 ```bash
 sudo apt-get update
-sudo apt-get install software-properties-common autoconf git build-essential libtool libprotobuf-c-dev libgmp-dev libsqlite3-dev python python3 zip libevent-dev pkg-config libssl-dev libcurl4-gnutls-dev make libboost-all-dev automake jq wget ninja-build libsqlite3-dev libgmp3-dev valgrind libcli-dev libsecp256k1-dev libsodium-dev libbase58-dev nano tmux
+sudo apt-get install software-properties-common autoconf git build-essential libtool libprotobuf-c-dev libgmp-dev libsqlite3-dev python python3 python3-mako zip libevent-dev pkg-config libssl-dev libcurl4-gnutls-dev make libboost-all-dev automake jq wget ninja-build libsqlite3-dev libgmp3-dev valgrind libcli-dev libsecp256k1-dev libsodium-dev libbase58-dev nano tmux
 
 # Install Berkeley 4.8 db libs (chips dependecy)
 # Source: https://cryptoandcoffee.com/mining-gems/install-berkeley-4-8-db-libs-on-ubuntu-16-04/


### PR DESCRIPTION
python3-mako is necessary for `lightning` compilation

 It's included in `lightning/docs/INSTALL.md`, but not in this repository's dependency line.  If this is intended, please feel free to disregard.
