### PR TITLE
Adding cashier GUI servers

### DIFF
--- a/docs/protocol/dealer_setup.md
+++ b/docs/protocol/dealer_setup.md
@@ -8,12 +8,12 @@ The compilation instructions for any node of a bet is same, please follow the co
 All the configurable options for the player can be set in `dealer_setup.ini` file, which is located at `bet/privatebet/config` path. The default content of this file is as follows:
 ```
 [dealer]
-max_players =	3 #This is the maximun number of players that dealer will allow them to join the table. Atm, dealer waits for this number of players to join before starting hand.
-table_stack_in_chips=	0.01000000 #This is the amount of CHIPS that needed to join the table.
-dcv_commission= 0.5 #This is the percentage of the pot amount that dealer takes home as commission.
-chips_tx_fee=	0.00050000 #The default tx_fee is `0.0001` dealer can set any amount greater than minimum tx_fee.
-type= torv3 #When this set dealer only allows LN nodes running on torv3 to establish channels with it. This feature is not activated yet.
-gui_host = ""#If the GUI is hosted on the same backend node then it can be left blank, else the URL on which the GUI is hosted must be provided.
+max_players           = 3           #This is the maximun number of players that dealer will allow them to join the table. Atm, dealer waits for this number of players to join before starting hand.
+table_stack_in_chips  = 0.01000000  #This is the amount of CHIPS that needed to join the table.
+dcv_commission        = 0.5         #This is the percentage of the pot amount that dealer takes home as commission.				
+chips_tx_fee          = 0.00050000  #The default tx_fee is `0.0001` dealer can set any amount greater than minimum tx_fee.
+type                  = torv3       #When this set dealer only allows LN nodes running on torv3 to establish channels with it. This feature is not activated yet.
+gui_host              = ""          #If the GUI is hosted on the same backend node then it can be left blank, else the URL on which the GUI is hosted must be provided.
 ```
 
 ## Running the dealer node

--- a/docs/protocol/player_setup.md
+++ b/docs/protocol/player_setup.md
@@ -8,9 +8,9 @@ In order to setup the player node follow either the [basic compilation guide](./
 All the configurable options for the player can be set in `player_setup.ini` file, which is located at `bet/privatebet/config` path. The default content of this file is as follows:
 ```
 [player]
-max_allowed_dcv_commission = 5 #This is the max percentage of the dealer commision that the player is willing to pay, if the dealer sets the commission higher than this then the backend node will exit.
-type = torv3 #This will enforce LN and CHIPS run on onion address, atm this will be ignored.
-[gui] #These are GUI's hosted by the cashier nodes, player can pick any of them in order to connect to its backend from these.
+max_allowed_dcv_commission = 5      #This is the max percentage of the dealer commision that the player is willing to pay, if the dealer sets the commission higher than this then the backend node will exit.
+type                       = torv3  #This will enforce LN and CHIPS run on onion address, atm this will be ignored.
+[gui]                               #These are GUI's hosted by the cashier nodes, player can pick any of them in order to connect to its backend from these.
 cashier-1 = http://141.94.227.65:1234/
 cashier-2 = http://141.94.227.66:1234/
 cashier-3 = http://141.94.227.67:1234/

--- a/docs/protocol/player_setup.md
+++ b/docs/protocol/player_setup.md
@@ -10,6 +10,12 @@ All the configurable options for the player can be set in `player_setup.ini` fil
 [player]
 max_allowed_dcv_commission = 5 #This is the max percentage of the dealer commision that the player is willing to pay, if the dealer sets the commission higher than this then the backend node will exit.
 type = torv3 #This will enforce LN and CHIPS run on onion address, atm this will be ignored.
+[gui] #These are GUI's hosted by the cashier nodes, player can pick any of them in order to connect to its backend from these.
+cashier-1 = http://141.94.227.65:1234/
+cashier-2 = http://141.94.227.66:1234/
+cashier-3 = http://141.94.227.67:1234/
+cashier-4 = http://141.94.227.68:1234/
+cashier-5 = http://159.69.23.30:1234/
 ```
 
 ## Running the player node

--- a/privatebet/bet.c
+++ b/privatebet/bet.c
@@ -363,6 +363,13 @@ static void playing_nodes_init()
 static void dealer_node_init()
 {
 	bet_parse_dealer_config_ini_file();
+	if (0 == strlen(dcv_hosted_gui_url)) {
+		sprintf(dcv_hosted_gui_url, "http://%s:1234/", dealer_ip);
+	}
+	dlg_warn("Delaer GUI URL :: %s", dcv_hosted_gui_url); // dlg_warn is just to highlight the log in the console
+	if (0 == check_url(dcv_hosted_gui_url))
+		memset(dcv_hosted_gui_url, 0x00, sizeof(dcv_hosted_gui_url));
+
 	bet_set_table_id();
 	bet_compute_m_of_n_msig_addr();
 	bet_game_multisigaddress();

--- a/privatebet/client.c
+++ b/privatebet/client.c
@@ -35,6 +35,7 @@
 #include "cashier.h"
 #include "misc.h"
 #include "host.h"
+#include "config.h"
 
 #define LWS_PLUGIN_STATIC
 
@@ -1482,11 +1483,13 @@ static int32_t bet_player_handle_stack_info_resp(cJSON *argjson, struct privateb
 
 	if (0 == check_url(jstr(argjson, "gui_url"))) {
 		if (0 == strlen(jstr(argjson, "gui_url"))) {
-			dlg_warn("Dealer is not hosting the GUI, so exiting...");
+			dlg_warn("Dealer is not hosting the GUI");
 		} else {
-			dlg_warn("Dealer hosted GUI :: %s is not reachable, so exiting...", jstr(argjson, "gui_url"));
+			dlg_warn("Dealer hosted GUI :: %s is not reachable", jstr(argjson, "gui_url"));
 		}
-		exit(-1);
+		dlg_info("Player can use any of the GUI's hosted by cashiers to connect to backend");
+		bet_display_cashier_hosted_gui();
+		
 	} else {
 		dlg_warn("Dealer hosted GUI :: %s, using this you can connect to player backend and interact",
 			 jstr(argjson, "gui_url"));

--- a/privatebet/client.c
+++ b/privatebet/client.c
@@ -1480,6 +1480,17 @@ static int32_t bet_player_handle_stack_info_resp(cJSON *argjson, struct privateb
 	int32_t retval = 1, bytes;
 	char *hex_data = NULL, *sql_query = NULL;
 
+	if (0 == check_url(jstr(argjson, "gui_url"))) {
+		if (0 == strlen(jstr(argjson, "gui_url"))) {
+			dlg_warn("Dealer is not hosting the GUI, so exiting...");
+		} else {
+			dlg_warn("Dealer hosted GUI :: %s is not reachable, so exiting...", jstr(argjson, "gui_url"));
+		}
+		exit(-1);
+	} else {
+		dlg_warn("Dealer hosted GUI :: %s, using this you can connect to player backend and interact",
+			 jstr(argjson, "gui_url"));
+	}
 	funds_needed = jdouble(argjson, "table_stack_in_chips");
 	if (jdouble(argjson, "dcv_commission") > max_allowed_dcv_commission) {
 		dlg_warn(

--- a/privatebet/common.h
+++ b/privatebet/common.h
@@ -116,5 +116,5 @@ extern char unique_id[65];
 
 extern double dcv_commission_percentage;
 extern double max_allowed_dcv_commission;
-
+extern char dcv_hosted_gui_url[128];
 #endif

--- a/privatebet/config.c
+++ b/privatebet/config.c
@@ -125,8 +125,9 @@ void bet_parse_dealer_config_ini_file()
 		if (0 != iniparser_getdouble(ini, "dealer:dcv_commission", 0)) {
 			dcv_commission_percentage = iniparser_getdouble(ini, "dealer:dcv_commission", 0);
 		}
-		dlg_info("The maxplayers for the table set by dealer is :: %d, dealers can change this in the %s",
-			 max_players, dealer_config_ini_file);
+		if (NULL != iniparser_getstring(ini, "dealer:gui_host", NULL)) {
+			strcpy(dcv_hosted_gui_url, iniparser_getstring(ini, "dealer:gui_host", NULL));
+		}
 	}
 }
 

--- a/privatebet/config.c
+++ b/privatebet/config.c
@@ -1,6 +1,7 @@
 #include "bet.h"
 #include "config.h"
 #include "common.h"
+#include "misc.h"
 
 char *dealer_config_file = "./config/dealer_config.json";
 char *player_config_file = "./config/player_config.json";
@@ -180,6 +181,26 @@ void bet_parse_cashier_config_ini_file()
 
 			strncpy(notary_node_ips[i], jstr(node_info, "ip"), strlen(jstr(node_info, "ip")));
 			strncpy(notary_node_pubkeys[i], jstr(node_info, "pubkey"), strlen(jstr(node_info, "pubkey")));
+		}
+	}
+}
+
+void bet_display_cashier_hosted_gui()
+{
+	dictionary *ini = NULL;
+	
+	ini = iniparser_load(player_config_ini_file);
+	if (ini == NULL) {
+		dlg_error("error in parsing %s", player_config_ini_file);
+	} else {
+		char str[20];
+		int i = 1;
+		sprintf(str, "gui:cashier-%d", i);
+		while (NULL != iniparser_getstring(ini, str, NULL)) {
+			if(check_url(iniparser_getstring(ini, str, NULL)))
+				dlg_warn("%s", iniparser_getstring(ini, str, NULL));
+			memset(str, 0x00, sizeof(str));
+			sprintf(str, "gui:cashier-%d", ++i);
 		}
 	}
 }

--- a/privatebet/config.h
+++ b/privatebet/config.h
@@ -6,3 +6,4 @@ void bet_parse_player_config_file();
 void bet_parse_dealer_config_ini_file();
 void bet_parse_player_config_ini_file();
 void bet_parse_cashier_config_ini_file();
+void bet_display_cashier_hosted_gui();

--- a/privatebet/config/dealer_config.ini
+++ b/privatebet/config/dealer_config.ini
@@ -1,7 +1,7 @@
 [dealer]
-max_players =	3
-table_stack_in_chips=	0.01000000
-dcv_commission= 0.5
-chips_tx_fee=	0.00050000
-type= torv3
-gui_host = ""#If the GUI is hosted on the same backend node then it can be left blank, else the URL on which the GUI is hosted must be provided.
+max_players			 = 3  		   #This is the maximun number of players that dealer will allow them to join the table. Atm, dealer waits for this number of players to join before starting hand.
+table_stack_in_chips = 0.01000000  #This is the amount of CHIPS that needed to join the table.
+dcv_commission       = 0.5		   #This is the percentage of the pot amount that dealer takes home as commission.				
+chips_tx_fee		 = 0.00050000  #The default tx_fee is `0.0001` dealer can set any amount greater than minimum tx_fee.
+type				 = torv3	   #When this set dealer only allows LN nodes running on torv3 to establish channels with it. This feature is not activated yet.
+gui_host 			 = ""		   #If the GUI is hosted on the same backend node then it can be left blank, else the URL on which the GUI is hosted must be provided.

--- a/privatebet/config/dealer_config.ini
+++ b/privatebet/config/dealer_config.ini
@@ -4,3 +4,4 @@ table_stack_in_chips=	0.01000000
 dcv_commission= 0.5
 chips_tx_fee=	0.00050000
 type= torv3
+gui_host = ""#If the GUI is hosted on the same backend node then it can be left blank, else the URL on which the GUI is hosted must be provided.

--- a/privatebet/config/player_config.ini
+++ b/privatebet/config/player_config.ini
@@ -1,3 +1,9 @@
 [player]
 max_allowed_dcv_commission = 5
 type = torv3
+[gui]
+cashier-1 = http://141.94.227.65:1234/
+cashier-2 = http://141.94.227.66:1234/
+cashier-3 = http://141.94.227.67:1234/
+cashier-4 = http://141.94.227.68:1234/
+cashier-5 = http://159.69.23.30:1234/

--- a/privatebet/config/player_config.ini
+++ b/privatebet/config/player_config.ini
@@ -1,7 +1,7 @@
 [player]
-max_allowed_dcv_commission = 5
-type = torv3
-[gui]
+max_allowed_dcv_commission = 5      #This is the max percentage of the dealer commision that the player is willing to pay, if the dealer sets the commission higher than this then the backend node will exit.
+type 					   = torv3  #This will enforce LN and CHIPS run on onion address, atm this will be ignored.
+[gui]  								#These are GUI's hosted by the cashier nodes, player can pick any of them in order to connect to its backend from these.
 cashier-1 = http://141.94.227.65:1234/
 cashier-2 = http://141.94.227.66:1234/
 cashier-3 = http://141.94.227.67:1234/

--- a/privatebet/host.c
+++ b/privatebet/host.c
@@ -87,6 +87,7 @@ int ws_dcv_connection_status = 0;
 
 double dcv_commission_percentage = 0.75;
 double dev_fund_percentage = 0.25;
+char dcv_hosted_gui_url[128];
 
 int32_t heartbeat_on = 0;
 
@@ -1353,6 +1354,7 @@ static int32_t bet_dcv_stack_info_resp(cJSON *argjson, struct privatebet_info *b
 	cJSON_AddStringToObject(stack_info_resp, "legacy_m_of_n_msig_addr", legacy_m_of_n_msig_addr);
 	cJSON_AddStringToObject(stack_info_resp, "table_id", table_id);
 	cJSON_AddNumberToObject(stack_info_resp, "threshold_value", threshold_value);
+	cJSON_AddStringToObject(stack_info_resp, "gui_url", dcv_hosted_gui_url);
 	msig_addr_nodes = cJSON_CreateArray();
 	for (int32_t i = 0; i < no_of_notaries; i++) {
 		if (notary_status[i] == 1) {

--- a/privatebet/misc.c
+++ b/privatebet/misc.c
@@ -1,4 +1,6 @@
 #include "misc.h"
+#include "../includes/curl/curl.h"
+#include "../includes/curl/easy.h"
 
 int32_t hexstr_to_str(char *input, char *output)
 {
@@ -54,4 +56,21 @@ void delete_file(char *file_name)
 	if (remove(file_name) != 0) {
 		dlg_warn("Intermediate file %s is not removed", file_name);
 	}
+}
+
+int check_url(char *url)
+{
+	CURL *curl = NULL;
+	CURLcode response;
+
+	curl = curl_easy_init();
+
+	if (curl) {
+		curl_easy_setopt(curl, CURLOPT_URL, url);
+		curl_easy_setopt(curl, CURLOPT_NOBODY, 1);
+		response = curl_easy_perform(curl);
+		curl_easy_cleanup(curl);
+	}
+
+	return (response == CURLE_OK) ? 1 : 0;
 }

--- a/privatebet/misc.c
+++ b/privatebet/misc.c
@@ -58,7 +58,7 @@ void delete_file(char *file_name)
 	}
 }
 
-int check_url(char *url)
+int check_url(const char *url)
 {
 	CURL *curl = NULL;
 	CURLcode response;

--- a/privatebet/misc.h
+++ b/privatebet/misc.h
@@ -2,3 +2,4 @@
 int32_t hexstr_to_str(char *input, char *output);
 void str_to_hexstr(char *input, char *output);
 void delete_file(char *file_name);
+int check_url(char *url);

--- a/privatebet/misc.h
+++ b/privatebet/misc.h
@@ -2,4 +2,4 @@
 int32_t hexstr_to_str(char *input, char *output);
 void str_to_hexstr(char *input, char *output);
 void delete_file(char *file_name);
-int check_url(char *url);
+int check_url(const char *url);


### PR DESCRIPTION
The player needs GUI in order to connect to its backend and play the game. This GUI can be hosted by either dealer or cashier nodes.
Now all the cashier nodes are configured to host the GUI and the player can pick one in the absence of dealer GUI or in the presence of it. At present there are no special incentives for cashier nodes to host the GUI's and to act as blinders during deck shuffling. Since the cashier nodes are offering more functionalities going forward their incentives will be increased.