### PR TITLE
Making table stack size as 200 BB

### DIFF
--- a/privatebet/cashier.c
+++ b/privatebet/cashier.c
@@ -62,8 +62,8 @@ Incase if these values are not mentioned in the dealer_config.json file, the def
 	table_stack_in_chips = 0.01;
 	chips_tx_fee = 0.0005;
 ***********************************************************************************************************/
-
-double table_stack_in_chips = 0.01;
+double BB_in_chips = 0.01;
+double table_stack_in_chips = 2;
 double chips_tx_fee = 0.0001;
 
 char *legacy_m_of_n_msig_addr = NULL;

--- a/privatebet/client.c
+++ b/privatebet/client.c
@@ -1496,6 +1496,7 @@ static void bet_handle_player_error(struct privatebet_info *bet, int32_t err_no)
 		break;
 	case ERR_DEALER_TABLE_FULL:
 		bet_raise_dispute(player_payin_txid);
+	case ERR_CHIPS_INSUFFICIENT_FUNDS:	
 	case ERR_PT_PLAYER_UNAUTHORIZED:
 	case ERR_DCV_COMMISSION_MISMATCH:
 	case ERR_INI_PARSING:

--- a/privatebet/common.h
+++ b/privatebet/common.h
@@ -95,6 +95,7 @@ extern int32_t threshold_value;
 extern char **notary_node_ips;
 extern char **notary_node_pubkeys;
 
+extern double BB_in_chips;
 extern double table_stack_in_chips;
 extern double chips_tx_fee;
 

--- a/privatebet/config.c
+++ b/privatebet/config.c
@@ -109,7 +109,6 @@ void bet_parse_player_config_file()
 void bet_parse_dealer_config_ini_file()
 {
 	dictionary *ini = NULL;
-	double big_blind = 0.01;
 	
 	ini = iniparser_load(dealer_config_ini_file);
 	if (ini == NULL) {
@@ -118,13 +117,10 @@ void bet_parse_dealer_config_ini_file()
 		if (-1 != iniparser_getint(ini, "dealer:max_players", -1)) {
 			max_players = iniparser_getint(ini, "dealer:max_players", -1);
 		}
-		if (0 != iniparser_getdouble(ini, "dealer:table_stack_in_chips", 0)) {
-			table_stack_in_chips = iniparser_getdouble(ini, "dealer:table_stack_in_chips", 0);
-		}
 		if (0 != iniparser_getdouble(ini, "dealer:big_blind", 0)) {
-			big_blind = iniparser_getdouble(ini, "dealer:big_blind", 0);		
+			BB_in_chips = iniparser_getdouble(ini, "dealer:big_blind", 0);		
 		}
-		table_stack_in_chips = 200 * big_blind;
+		table_stack_in_chips = 200 * BB_in_chips;
 		if (0 != iniparser_getdouble(ini, "dealer:chips_tx_fee", 0)) {
 			chips_tx_fee = iniparser_getdouble(ini, "dealer:chips_tx_fee", 0);
 		}

--- a/privatebet/config.c
+++ b/privatebet/config.c
@@ -109,7 +109,8 @@ void bet_parse_player_config_file()
 void bet_parse_dealer_config_ini_file()
 {
 	dictionary *ini = NULL;
-
+	double big_blind = 0.01;
+	
 	ini = iniparser_load(dealer_config_ini_file);
 	if (ini == NULL) {
 		dlg_error("error in parsing %s", dealer_config_ini_file);
@@ -120,6 +121,10 @@ void bet_parse_dealer_config_ini_file()
 		if (0 != iniparser_getdouble(ini, "dealer:table_stack_in_chips", 0)) {
 			table_stack_in_chips = iniparser_getdouble(ini, "dealer:table_stack_in_chips", 0);
 		}
+		if (0 != iniparser_getdouble(ini, "dealer:big_blind", 0)) {
+			big_blind = iniparser_getdouble(ini, "dealer:big_blind", 0);		
+		}
+		table_stack_in_chips = 200 * big_blind;
 		if (0 != iniparser_getdouble(ini, "dealer:chips_tx_fee", 0)) {
 			chips_tx_fee = iniparser_getdouble(ini, "dealer:chips_tx_fee", 0);
 		}
@@ -151,7 +156,6 @@ void bet_parse_player_config_ini_file()
 		}
 		if (0 != iniparser_getstring(ini, "player:name", NULL)) {
 			strcpy(player_name, iniparser_getstring(ini, "player:name", NULL));
-			dlg_info("name::%s", player_name);
 		}
 		if (-1 != iniparser_getboolean(ini, "private table:is_table_private", -1)) {
 			is_table_private = iniparser_getboolean(ini, "private table:is_table_private", -1);

--- a/privatebet/config/dealer_config.ini
+++ b/privatebet/config/dealer_config.ini
@@ -1,6 +1,6 @@
 [dealer]
 max_players			 = 2  		   #This is the maximun number of players that dealer will allow them to join the table. Atm, dealer waits for this number of players to join before starting hand.
-table_stack_in_chips = 0.01000000  #This is the amount of CHIPS that needed to join the table.
+big_blind 			 = 0.01		   #If this value is set the table stack size is calculated based on this which is 200BB, if this value is not set the default value is 0.01.		
 dcv_commission       = 0.5		   #This is the percentage of the pot amount that dealer takes home as commission.				
 chips_tx_fee		 = 0.00050000  #The default tx_fee is `0.0001` dealer can set any amount greater than minimum tx_fee.
 type				 = torv3	   #When this set dealer only allows LN nodes running on torv3 to establish channels with it. This feature is not activated yet.

--- a/privatebet/host.c
+++ b/privatebet/host.c
@@ -1466,8 +1466,8 @@ static int32_t bet_dcv_process_tx(cJSON *argjson, struct privatebet_info *bet, s
 	pthread_mutex_unlock(&mutex);
 
 	double balance = chips_get_balance_on_address_from_tx(addr, jstr(argjson, "tx_info"));
-	funds = (balance * satoshis) / (satoshis_per_unit * normalization_factor);
-
+	//funds = (balance * satoshis) / (satoshis_per_unit * normalization_factor);
+	funds = (balance *2)/ BB_in_chips;
 	char *rand_str = jstr(argjson, "id");
 	for (int i = 0; i < no_of_rand_str; i++) {
 		if (strcmp(tx_rand_str[i], rand_str) == 0)


### PR DESCRIPTION
The issue https://github.com/chips-blockchain/bet/issues/308 has been fixed, now the dealer can configure the BB and based on the table stack size is calculated which is 200BB.